### PR TITLE
feat: リリースノートの表示形式を変更

### DIFF
--- a/src/app/[locale]/release-notes/page.tsx
+++ b/src/app/[locale]/release-notes/page.tsx
@@ -66,9 +66,18 @@ export default function ReleaseNotesPage() {
                                         {currentChanges.newFeatures && currentChanges.newFeatures.length > 0 && (
                                             <div className="mb-4">
                                                 <h3 className="font-semibold text-lg mb-2 text-green-500 dark:text-green-400">{t('newFeaturesTitle')}</h3>
-                                                <ul className="list-disc pl-5 space-y-1 text-sm">
+                                                <ul className="list-none pl-0 space-y-3">
                                                     {currentChanges.newFeatures.map((feature, i) => (
-                                                        <li key={`new-${i}`}>{feature}</li>
+                                                        <li key={`new-${i}`} className="border-l-4 border-green-500 pl-3">
+                                                            <p className="font-medium">{feature.title}</p>
+                                                            {feature.descriptions && feature.descriptions.length > 0 && (
+                                                                <ul className="list-disc pl-5 mt-1 space-y-1 text-sm text-muted-foreground">
+                                                                    {feature.descriptions.map((desc, j) => (
+                                                                        <li key={`new-desc-${i}-${j}`}>{desc}</li>
+                                                                    ))}
+                                                                </ul>
+                                                            )}
+                                                        </li>
                                                     ))}
                                                 </ul>
                                             </div>

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -5,12 +5,22 @@
         "changes": {
             "ja": {
                 "newFeatures": [
-                    "「Adoかるた」サイトへようこそ！このサイトでは、Adoさんの楽曲カルタの読み上げや、カルタの一覧表示を楽しむことができます。"
+                    {
+                        "title": "「Adoかるた」サイトへようこそ！",
+                        "descriptions": [
+                            "このサイトでは、Adoさんの楽曲カルタの読み上げや、カルタの一覧表示を楽しむことができます。"
+                        ]
+                    }
                 ]
             },
             "en": {
                 "newFeatures": [
-                    "Welcome to the \"Ado Karuta\" site! Here you can enjoy having Ado's song karuta read aloud and viewing a list of the karuta cards."
+                    {
+                        "title": "Welcome to the \"Ado Karuta\" site!",
+                        "descriptions": [
+                            "Here you can enjoy having Ado's song karuta read aloud and viewing a list of the karuta cards."
+                        ]
+                    }
                 ]
             }
         }

--- a/src/types/release-notes.ts
+++ b/src/types/release-notes.ts
@@ -1,5 +1,10 @@
+export interface ChangeItem {
+    title: string;
+    descriptions?: string[];
+}
+
 export interface LocalizedChanges {
-    newFeatures?: string[];
+    newFeatures?: ChangeItem[];
     improvements?: string[];
     bugFixes?: string[];
 }


### PR DESCRIPTION
リリースノートの表示形式を更新しました。

主な変更点:
- JSONデータのフォーマットを変更し、各項目にタイトルと説明(複数可、オプショナル)を持てるようにしました。
- 型定義 (`src/types/release-notes.ts`) を更新しました。
- リリースノートページ (`src/app/[locale]/release-notes/page.tsx`) を修正し、新しいデータ構造に対応しました。