### PR TITLE
feat: #3 - イントロから再生するオプション機能の実装

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
@@ -23,6 +23,20 @@ export function Header() {
     const pathname = usePathname();
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isDialogOpen, setIsDialogOpen] = useState(false); // 設定モーダル用の state
+    const [isIntroMode, setIsIntroMode] = useState(false); // イントロモード用の state を追加
+
+    useEffect(() => {
+        // localStorageからイントロモードの設定を読み込む
+        const storedIntroMode = localStorage.getItem('introModeEnabled');
+        if (storedIntroMode) {
+            setIsIntroMode(JSON.parse(storedIntroMode));
+        }
+    }, []);
+
+    const handleIntroModeChange = (checked: boolean) => {
+        setIsIntroMode(checked);
+        localStorage.setItem('introModeEnabled', JSON.stringify(checked));
+    };
 
     const toggleMenu = () => {
         setIsMenuOpen(!isMenuOpen);
@@ -131,7 +145,11 @@ export function Header() {
                     </DialogHeader>
                     <div className="grid gap-4 py-4">
                         <div className="flex items-center space-x-2">
-                            <Switch id="intro-mode" />
+                            <Switch
+                                id="intro-mode"
+                                checked={isIntroMode}
+                                onCheckedChange={handleIntroModeChange}
+                            />
                             <Label htmlFor="intro-mode">{t('settingIntroMode')}</Label>
                         </div>
                         <div className="flex items-center space-x-2">

--- a/src/components/YomiagePlayer.tsx
+++ b/src/components/YomiagePlayer.tsx
@@ -167,9 +167,16 @@ export function YomiagePlayer({ initialKartaData }: YomiagePlayerProps) {
     const loadAndPlayVideo = (karta: Karta) => {
         const player = playerRef.current;
         if (player && karta) {
+            let startSeconds = karta.startSeconds;
+            if (typeof window !== 'undefined') {
+                const introModeEnabled = localStorage.getItem('introModeEnabled');
+                if (introModeEnabled && JSON.parse(introModeEnabled)) {
+                    startSeconds = 0; // イントロモードが有効なら再生開始時間を0に
+                }
+            }
             player.loadVideoById({
                 videoId: karta.youtubeId,
-                startSeconds: karta.startSeconds
+                startSeconds: startSeconds
             });
         } else {
             console.error('Player instance not available or karta is null.');


### PR DESCRIPTION
## 概要

Issue #3 に対応し、「イントロから再生モード」のオプション機能を追加しました。

## 変更点

- 設定ダイアログに「イントロから再生モード」のトグルスイッチを追加。
- トグルスイッチの状態はlocalStorageに保存され、ページを跨いで設定が維持されます。
- 「イントロから再生モード」が有効な場合、読み上げプレイヤーは各カルタに設定された開始時間ではなく、動画の最初から再生するようになります。

## 関連Issue

- Closes #3