### PR TITLE
improvements: #7 - 終盤の読み上げにフェイクカルタを混ぜる機能の実装

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,8 @@
         "settingsTitle": "Display Settings",
         "settingsDescription": "Change settings related to Karta display and playback.",
         "settingIntroMode": "Play from intro mode",
-        "settingFakeLastCard": "Fake out for last card"
+        "settingFakeLastCard": "Fake out for last card",
+        "settingEnableShuffleFakeMode": "Include already played songs when few cards remain (Shuffle Fake Mode)"
     },
     "GlobalMetadata": {
         "siteTitle": "Ado Karuta",

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,6 @@
         "settingsTitle": "Display Settings",
         "settingsDescription": "Change settings related to Karta display and playback.",
         "settingIntroMode": "Play from intro mode",
-        "settingFakeLastCard": "Fake out for last card",
         "settingEnableShuffleFakeMode": "Include already played songs when few cards remain (Shuffle Fake Mode)"
     },
     "GlobalMetadata": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -39,8 +39,7 @@
         "settingsTitle": "表示設定",
         "settingsDescription": "カルタの表示や再生に関する設定を変更します。",
         "settingIntroMode": "イントロから再生モード",
-        "settingFakeLastCard": "最後の札のフェイク演出",
-        "settingEnableShuffleFakeMode": "枚数が少なくなったら再生済みの曲も含める"
+        "settingEnableShuffleFakeMode": "終盤に再生済みの読み札も含める"
     },
     "GlobalMetadata": {
         "siteTitle": "Ado かるた",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -39,7 +39,8 @@
         "settingsTitle": "表示設定",
         "settingsDescription": "カルタの表示や再生に関する設定を変更します。",
         "settingIntroMode": "イントロから再生モード",
-        "settingFakeLastCard": "最後の札のフェイク演出"
+        "settingFakeLastCard": "最後の札のフェイク演出",
+        "settingEnableShuffleFakeMode": "枚数が少なくなったら再生済みの曲も含める"
     },
     "GlobalMetadata": {
         "siteTitle": "Ado かるた",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,7 @@ export function Header() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isDialogOpen, setIsDialogOpen] = useState(false); // 設定モーダル用の state
     const [isIntroMode, setIsIntroMode] = useState(false); // イントロモード用の state を追加
+    const [isShuffleFakeModeEnabled, setIsShuffleFakeModeEnabled] = useState(false); // フェイクモード用のstate
 
     useEffect(() => {
         // localStorageからイントロモードの設定を読み込む
@@ -31,11 +32,20 @@ export function Header() {
         if (storedIntroMode) {
             setIsIntroMode(JSON.parse(storedIntroMode));
         }
+        const storedShuffleFakeMode = localStorage.getItem('shuffleFakeModeEnabled'); // ローカルストレージから読み込み
+        if (storedShuffleFakeMode) {
+            setIsShuffleFakeModeEnabled(JSON.parse(storedShuffleFakeMode));
+        }
     }, []);
 
     const handleIntroModeChange = (checked: boolean) => {
         setIsIntroMode(checked);
         localStorage.setItem('introModeEnabled', JSON.stringify(checked));
+    };
+
+    const handleShuffleFakeModeChange = (checked: boolean) => { // フェイクモード変更ハンドラ
+        setIsShuffleFakeModeEnabled(checked);
+        localStorage.setItem('shuffleFakeModeEnabled', JSON.stringify(checked));
     };
 
     const toggleMenu = () => {
@@ -153,8 +163,12 @@ export function Header() {
                             <Label htmlFor="intro-mode">{t('settingIntroMode')}</Label>
                         </div>
                         <div className="flex items-center space-x-2">
-                            <Switch id="fake-last-card" />
-                            <Label htmlFor="fake-last-card">{t('settingFakeLastCard')}</Label>
+                            <Switch
+                                id="shuffle-fake-mode"
+                                checked={isShuffleFakeModeEnabled}
+                                onCheckedChange={handleShuffleFakeModeChange}
+                            />
+                            <Label htmlFor="shuffle-fake-mode">{t('settingEnableShuffleFakeMode')}</Label>
                         </div>
                     </div>
                     {isYomiagePage && (


### PR DESCRIPTION
## 関連Issue

- close #7

## 概要

カルタゲームの終盤において、既に読み上げられた札をフェイクとして再生する機能を追加し、ゲームの難易度と面白さを向上させます。具体的には、残り札が3枚以下になった場合に50%の確率でフェイク動画が再生されるようにします。この機能は設定画面からON/OFF可能です。

## 主な変更点

- `Karta` インターフェースに `isFake?: boolean` プロパティを追加しました。
- `shuffleArray` 関数を修正し、終盤にフェイクカルタを挿入するロジックを追加しました。
  - フェイクカルタの元ネタは、それ以前に読み上げられたカルタからランダムに選択されます（現在処理中のカルタ自身は除外）。
  - フェイクカルタは、現在処理しているオリジナルカルタの直前に挿入されます。
- `YomiagePlayer` コンポーネントを修正しました。
  - 表示される総枚数と現在のカウントが、フェイクカルタを除いた実際のカルタ数になるようにしました。
  - ローカルストレージへのゲーム状態保存・復元時に `isFake` プロパティが正しく扱われるように `GameState` インターフェースを更新しました。
- `Header.tsx` にある設定トグル（「枚数が少なくなったら再生済みの曲も含める」）と連携し、機能のON/OFFをローカルストレージ (`shuffleFakeModeEnabled`) で管理するようにしました。
- `YomiagePlayer.tsx` の `initializePlaylist` で上記設定を読み込み、フェイク挿入の有無を制御するようにしました。
- 関連する翻訳キーとテキスト (`settingEnableShuffleFakeMode`) を `messages/ja.json`, `messages/en.json` に追加・修正し、古いキー (`settingFakeLastCard`) は削除しました。
