### PR TITLE
1.2.1: Release note/Version increment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ado-karta",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -168,5 +168,35 @@
                 ]
             }
         }
+    },
+    {
+        "version": "1.2.1",
+        "releaseDate": "2025/06/03",
+        "changes": {
+            "ja": {
+                "newFeatures": [],
+                "improvements": [
+                    {
+                        "title": "動画の読み込み状態に応じた再生ボタンの表示制御を実装しました。",
+                        "descriptions": [
+                            "動画が準備できるまでは再生ボタンをグレーアウトし、準備完了後は青色のボタンに変更することで、操作可能なタイミングを視覚的に分かりやすくしました。"
+                        ]
+                    }
+                ],
+                "bugFixes": []
+            },
+            "en": {
+                "newFeatures": [],
+                "improvements": [
+                    {
+                        "title": "Implemented display control for the play button based on video loading status.",
+                        "descriptions": [
+                            "The play button is now grayed out until the video is ready, and then changes to blue when ready, making it visually clear when it can be operated."
+                        ]
+                    }
+                ],
+                "bugFixes": []
+            }
+        }
     }
 ]


### PR DESCRIPTION
## Release Summary

### Version
1.2.1

### Release Date
2025/06/03

### Changes
#### ja
**改善点**
- 動画の読み込み状態に応じた再生ボタンの表示制御を実装しました。
  - 動画が準備できるまでは再生ボタンをグレーアウトし、準備完了後は青色のボタンに変更することで、操作可能なタイミングを視覚的に分かりやすくしました。

#### en
**Improvements**
- Implemented display control for the play button based on video loading status.
  - The play button is now grayed out until the video is ready, and then changes to blue when ready, making it visually clear when it can be operated.